### PR TITLE
Use long lines in the .txt file

### DIFF
--- a/invitation.txt
+++ b/invitation.txt
@@ -2,55 +2,23 @@
 
 ## Background
 
-The following draft text is an invitation to a critical project
-to request MFA tokens. In most cases these would be created
-as an issue on the project's GitHub/GitLab/etc. page, or sent as
-an email to their security contact email address.
-
-NOTE: This needs to be fixed, GitHub plans to distribute a form entry
-that would then give a coupon code.
+The following draft text is an invitation to a critical project to request MFA tokens. In most cases these would be created as an issue on the project's GitHub/GitLab/etc. page, or sent as an email to their security contact email address.
 
 Improvements welcome!
 
 ## Invitation text
 
-Hello! I am <YOUR NAME> and I work with the
-Developer Best Practices Working Group
-of the Linux Foundation's Open Source Security Foundation (OpenSSF) at
-<https://github.com/ossf/wg-best-practices-os-developers>
+@bagder and all other curl developers:
 
-We'd like to give your project *free*
-multi-factor authentication (MFA) hardware tokens from Google and GitHub,
-for use by your maintainers.
-We'd especially like to give them to any of your maintainers
-who aren't already using any.
-This is part of the "The Great MFA Distribution Project"
-<https://github.com/ossf/great-mfa-project> for
-developers of open source software (OSS)/Free Software to improve
-confidence in authentication and integrity of code being delivered.
+Hello! I am David A. Wheeler and I work with the Developer Best Practices Working Group of the Linux Foundation's Open Source Security Foundation (OpenSSF) at <https://github.com/ossf/wg-best-practices-os-developers>
 
-By **2021-12-20** and preferably much sooner,
-let us know how many you'd like.
-We can provide your project up to 5 Titan tokens from Google and up to
-5 Yubikey tokens from GitHub.  If you could use more, please let us know that
-too. We know many projects could use more, and we may
-be able to provide more at some point.
-In your response, tell us an email
-address where we can *privately* send you the coupon codes and
-validation codes needed to get the tokens.
+We'd like to give your project *free* multi-factor authentication (MFA) hardware tokens from Google and GitHub, for use by your maintainers. We'd especially like to give them to any of your maintainers who aren't already using any. This is part of the "The Great MFA Distribution Project". <https://github.com/ossf/great-mfa-project> for developers of open source software (OSS)/Free Software to improve confidence in authentication and integrity of code being delivered.
 
-We would send you coupon codes and validation codes to the private email
-address.
-You would send then distribute those codes to the maintainers you choose.
-The recipients would use the coupon codes and validation codes to "buy"
-the tokens from the Google Store and/or GitHub Shop, who would ship
-the tokens directly to recipients.  
-These codes are use-once, so
-make sure you can keep the codes private until they're used by the
-intended person.
+By **2021-12-20** and preferably much sooner, let us know how many you'd like. We can provide your project up to 5 Titan tokens from Google and up to 5 Yubikey tokens from GitHub.  If you could use more, please let us know that too. We know many projects could use more, and we may be able to provide more at some point. In your response, tell us an email address where we can *privately* send you the coupon codes and validation codes needed to get the tokens.
 
-**Important**: The Google coupon codes **must be used by 2021-12-31** on
-the Google Store or they expire.
+We would send you coupon codes and validation codes to the private email address. You would send then distribute those codes to the maintainers you choose. The recipients would use the coupon codes and validation codes to "buy" the tokens from the Google Store and/or GitHub Shop, who would ship the tokens directly to recipients.  These codes are use-once, so. make sure you can keep the codes private until they're used by the intended person.
+
+**Important**: The Google coupon codes **must be used by 2021-12-31** on the Google Store or they expire.
 
 To qualify, each token recipient must:
 
@@ -69,18 +37,8 @@ to tell us these numbers (preferably within 30 days of getting the codes):
 2. How many people received tokens from just Google? From just GitHub? From both?
 3. How many people didn’t have hardware tokens they used for OSS who received tokens from just Google? From just GitHub? From both?
 
-We ask for this information so we can tell others some simple
-measures of success. We don't need nor want the names of any
-individuals participating.
+We ask for this information so we can tell others some simple measures of success. We don't need nor want the names of any individuals participating.
 
-Please note that the tokens are shipped from the US, so while they
-can be shipped internationally, we can't ship somewhere if that is
-forbidden (sanctioned) under US law
-So at this time we are unable to ship to individuals in China,
-Afghanistan, Russia, Ukraine, North Korea, Iran, Sudan, and Syria.
-Sorry about that.
-More information is here: <https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information>
+Please note that the tokens are shipped from the US, so while they can be shipped internationally, we can't ship somewhere if that is forbidden (sanctioned) under US law. So at this time we are unable to ship to individuals in China, Afghanistan, Russia, Ukraine, North Korea, Iran, Sudan, and Syria. Sorry about that. More information is here: <https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information>
 
-For more information including how-tos and other setup information can be found at the
-"Great Multi-Factor Authentication (MFA) Distribution Project" site:
-<https://github.com/ossf/great-mfa-project>
+For more information including how-tos and other setup information can be found at the "Great Multi-Factor Authentication (MFA) Distribution Project" site: <https://github.com/ossf/great-mfa-project>

--- a/invitation.txt
+++ b/invitation.txt
@@ -16,7 +16,7 @@ We'd like to give your project *free* multi-factor authentication (MFA) hardware
 
 By **2021-12-20** and preferably much sooner, let us know how many you'd like. We can provide your project up to 5 Titan tokens from Google and up to 5 Yubikey tokens from GitHub.  If you could use more, please let us know that too. We know many projects could use more, and we may be able to provide more at some point. In your response, tell us an email address where we can *privately* send you the coupon codes and validation codes needed to get the tokens.
 
-We would send you coupon codes and validation codes to the private email address. You would send then distribute those codes to the maintainers you choose. The recipients would use the coupon codes and validation codes to "buy" the tokens from the Google Store and/or GitHub Shop, who would ship the tokens directly to recipients.  These codes are use-once, so. make sure you can keep the codes private until they're used by the intended person.
+We would send you coupon codes and validation codes to the private email address. You would then distribute those codes to the maintainers you choose. The recipients would use the coupon codes and validation codes to "buy" the tokens from the Google Store and/or GitHub Shop, who would ship the tokens directly to recipients.  These codes are use-once, so. make sure you can keep the codes private until they're used by the intended person.
 
 **Important**: The Google coupon codes **must be used by 2021-12-31** on the Google Store or they expire.
 


### PR DESCRIPTION
The .txt file works in GitHub issues, but the markdown variant
used by GitHub issues forces line returns when the text file does
(which isn't true for "normal" markdown). Thus, text files with lots
of line break look funny in it.

This commit merges the lines of a parapgraph into a single long line.
This works in both GitHub issues markdown and in email.
The goal is to have a single form we can use everywhere.

This also removes the intro comment about needing to handle validation codes;
our text now *does* handle validation codes.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>